### PR TITLE
 Send cookies with torrent request.

### DIFF
--- a/background/adapter/rutorrent.js
+++ b/background/adapter/rutorrent.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let torrentToWeb = (typeof torrentToWeb === 'undefined' ? {} : torrentToWeb);
+torrentToWeb = (typeof torrentToWeb === 'undefined' ? {} : torrentToWeb);
 
 if (typeof torrentToWeb.adapter === 'undefined') {
     torrentToWeb.adapter = {};

--- a/background/adapter/transmission.js
+++ b/background/adapter/transmission.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let torrentToWeb = (typeof torrentToWeb === 'undefined' ? {} : torrentToWeb);
+torrentToWeb = (typeof torrentToWeb === 'undefined' ? {} : torrentToWeb);
 
 if (typeof torrentToWeb.adapter === 'undefined') {
     torrentToWeb.adapter = {};

--- a/background/main.js
+++ b/background/main.js
@@ -1,12 +1,13 @@
 'use strict';
 
-let torrentToWeb = (typeof torrentToWeb === 'undefined' ? {} : torrentToWeb);
+var torrentToWeb = (typeof torrentToWeb === 'undefined' ? {} : torrentToWeb);
 
 torrentToWeb.processUrl = function (url) {
     torrentToWeb.notify('Retrieving torrent file');
 
     let request = new XMLHttpRequest();
     request.open('GET', url, true);
+    request.withCredentials = true;
     request.responseType = 'blob';
     request.onreadystatechange = function () {
         if (request.readyState !== XMLHttpRequest.DONE) {


### PR DESCRIPTION
Issue #9 

Also: Fix torrentToWeb variable redeclaration.
It was not possible to install the extension. Firefox was throwing an error and the context menu entry wasn't shown. Once the redeclaration of the torrentToWeb variable was removed the add-on installed as expected. Not sure what the redeclarations were there for. If this is wrong I'll fix it...