### PR TITLE
Implement magnet url handling

### DIFF
--- a/background/adapter/deluge.js
+++ b/background/adapter/deluge.js
@@ -47,23 +47,23 @@ torrentToWeb.adapter.deluge = function (baseUrl, username, password, autostart) 
                 login(() => {
                     sendRequest(requestData, callback, null);
                 });
-            } else {
-                let fileReader = new FileReader();
-
-                fileReader.addEventListener('load', function () {
-                    let requestData = {
-                        id: '2',
-                        method: 'core.add_torrent_file',
-                        params: [filenameOrUrl, window.btoa(fileReader.result), options],
-                    };
-
-                    login(() => {
-                        sendRequest(requestData, callback, null);
-                    });
-                });
-
-                fileReader.readAsBinaryString(data);
+                return;
             }
+            let fileReader = new FileReader();
+
+            fileReader.addEventListener('load', function () {
+                let requestData = {
+                    id: '2',
+                    method: 'core.add_torrent_file',
+                    params: [filenameOrUrl, window.btoa(fileReader.result), options],
+                };
+
+                login(() => {
+                    sendRequest(requestData, callback, null);
+                });
+            });
+
+            fileReader.readAsBinaryString(data);
         }
     };
 

--- a/background/adapter/deluge.js
+++ b/background/adapter/deluge.js
@@ -30,28 +30,40 @@ torrentToWeb.adapter.deluge = function (baseUrl, username, password, autostart) 
     }
 
     return {
-        send: function (filename, data, callback) {
-            let fileReader = new FileReader();
+        send: function (filenameOrUrl, data, callback) {
+            let options = {};
 
-            fileReader.addEventListener('load', function () {
-                let options = {};
+            if (! autostart) {
+                options['add_paused'] = true;
+            }
 
-                if (! autostart) {
-                    options['add_paused'] = true;
-                }
-
+            if (filenameOrUrl.startsWith('magnet:')) {
                 let requestData = {
                     id: '2',
-                    method: 'core.add_torrent_file',
-                    params: [filename, window.btoa(fileReader.result), options],
+                    method: 'core.add_torrent_magnet',
+                    params: [filenameOrUrl, options],
                 };
 
                 login(() => {
                     sendRequest(requestData, callback, null);
                 });
-            });
+            } else {
+                let fileReader = new FileReader();
 
-            fileReader.readAsBinaryString(data);
+                fileReader.addEventListener('load', function () {
+                    let requestData = {
+                        id: '2',
+                        method: 'core.add_torrent_file',
+                        params: [filenameOrUrl, window.btoa(fileReader.result), options],
+                    };
+
+                    login(() => {
+                        sendRequest(requestData, callback, null);
+                    });
+                });
+
+                fileReader.readAsBinaryString(data);
+            }
         }
     };
 

--- a/background/adapter/rutorrent.js
+++ b/background/adapter/rutorrent.js
@@ -8,14 +8,18 @@ torrentToWeb.adapter.rutorrent = function (baseUrl, username, password, autostar
     baseUrl = baseUrlObject.toString();
 
     return {
-        send: function (filename, data, callback) {
+        send: function (filenameOrUrl, data, callback) {
             let formData = new FormData();
 
             if (! autostart) {
                 formData.append('torrents_start_stopped', '1');
             }
 
-            formData.append('torrent_file', data, filename);
+            if (filenameOrUrl.startsWith('magnet:')) {
+                formData.append('url', filenameOrUrl);
+            } else {
+                formData.append('torrent_file', data, filenameOrUrl);
+            }
 
             let request = new XMLHttpRequest();
             request.open('POST', baseUrl + '/php/addtorrent.php', true);

--- a/background/adapter/transmission.js
+++ b/background/adapter/transmission.js
@@ -21,22 +21,22 @@ torrentToWeb.adapter.transmission = function (baseUrl, username, password, autos
                     },
                 };
                 sendRequest(requestData, callback, null);
-            } else {
-                let fileReader = new FileReader();
-                fileReader.addEventListener('load', function () {
-                    let requestData = {
-                        method: 'torrent-add',
-                        arguments: {
-                            metainfo: window.btoa(fileReader.result),
-                            paused: ! autostart,
-                        },
-                    };
-
-                    sendRequest(requestData, callback, null);
-                });
-
-                fileReader.readAsBinaryString(data);
+                return;
             }
+            let fileReader = new FileReader();
+            fileReader.addEventListener('load', function () {
+                let requestData = {
+                    method: 'torrent-add',
+                    arguments: {
+                        metainfo: window.btoa(fileReader.result),
+                        paused: ! autostart,
+                    },
+                };
+
+                sendRequest(requestData, callback, null);
+            });
+
+            fileReader.readAsBinaryString(data);
         }
     };
 

--- a/background/adapter/transmission.js
+++ b/background/adapter/transmission.js
@@ -11,21 +11,32 @@ torrentToWeb.adapter.transmission = function (baseUrl, username, password, autos
     baseUrl = baseUrlObject.toString();
 
     return {
-        send: function (filename, data, callback) {
-            let fileReader = new FileReader();
-            fileReader.addEventListener('load', function () {
+        send: function (filenameOrUrl, data, callback) {
+            if (filenameOrUrl.startsWith('magnet:')) {
                 let requestData = {
                     method: 'torrent-add',
                     arguments: {
-                        metainfo: window.btoa(fileReader.result),
+                        filename: filenameOrUrl,
                         paused: ! autostart,
                     },
                 };
-
                 sendRequest(requestData, callback, null);
-            });
+            } else {
+                let fileReader = new FileReader();
+                fileReader.addEventListener('load', function () {
+                    let requestData = {
+                        method: 'torrent-add',
+                        arguments: {
+                            metainfo: window.btoa(fileReader.result),
+                            paused: ! autostart,
+                        },
+                    };
 
-            fileReader.readAsBinaryString(data);
+                    sendRequest(requestData, callback, null);
+                });
+
+                fileReader.readAsBinaryString(data);
+            }
         }
     };
 

--- a/background/main.js
+++ b/background/main.js
@@ -12,38 +12,38 @@ torrentToWeb.processUrl = function (url, ref) {
                 torrentToWeb.notify(success ? 'Magnet link sent' : 'Error while sending magnet link');
             });
         });
-    } else {
-        torrentToWeb.notify('Retrieving torrent file');
+        return;
+    }
+    torrentToWeb.notify('Retrieving torrent file');
 
-        const downloadRequest = new Request(url, {
-            method: 'GET',
-            credentials: 'same-origin',
-            referrer: ref,
-        });
-        return fetch(downloadRequest).then((response) => {
-            if (response.status !== 200) {
-                torrentToWeb.notify('Could not download torrent file:' + response.status);
-                return;
-            }
+    const downloadRequest = new Request(url, {
+        method: 'GET',
+        credentials: 'same-origin',
+        referrer: ref,
+    });
+    return fetch(downloadRequest).then((response) => {
+        if (response.status !== 200) {
+            torrentToWeb.notify('Could not download torrent file:' + response.status);
+            return;
+        }
 
-            let filename = torrentToWeb.determineFilename(response);
-            let extension = filename.split('.').pop();
+        let filename = torrentToWeb.determineFilename(response);
+        let extension = filename.split('.').pop();
 
-            if (extension !== 'torrent') {
-                torrentToWeb.notify('File is not a torrent');
-                return;
-            }
+        if (extension !== 'torrent') {
+            torrentToWeb.notify('File is not a torrent');
+            return;
+        }
 
-            torrentToWeb.notify('Uploading torrent file');
-            torrentToWeb.createAdapter(function (adapter) {
-                response.blob().then(function (blob) {
-                    adapter.send(filename, blob, function (success) {
-                        torrentToWeb.notify(success ? 'Torrent file uploaded' : 'Error while uploading torrent file');
-                    });
+        torrentToWeb.notify('Uploading torrent file');
+        torrentToWeb.createAdapter(function (adapter) {
+            response.blob().then(function (blob) {
+                adapter.send(filename, blob, function (success) {
+                    torrentToWeb.notify(success ? 'Torrent file uploaded' : 'Error while uploading torrent file');
                 });
             });
         });
-    }
+    });
 };
 
 torrentToWeb.createAdapter = function (callback) {

--- a/background/main.js
+++ b/background/main.js
@@ -5,36 +5,45 @@ let torrentToWeb = {
 };
 
 torrentToWeb.processUrl = function (url, ref) {
-    torrentToWeb.notify('Retrieving torrent file');
-
-    const downloadRequest = new Request(url, {
-        method: 'GET',
-        credentials: 'same-origin',
-        referrer: ref,
-    });
-    return fetch(downloadRequest).then((response) => {
-        if (response.status !== 200) {
-            torrentToWeb.notify('Could not download torrent file:' + response.status);
-            return;
-        }
-
-        let filename = torrentToWeb.determineFilename(response);
-        let extension = filename.split('.').pop();
-
-        if (extension !== 'torrent') {
-            torrentToWeb.notify('File is not a torrent');
-            return;
-        }
-
-        torrentToWeb.notify('Uploading torrent file');
+    if (url.startsWith('magnet:')) {
+        torrentToWeb.notify('Sending magnet link');
         torrentToWeb.createAdapter(function (adapter) {
-            response.blob().then(function (blob) {
-                adapter.send(filename, blob, function (success) {
-                    torrentToWeb.notify(success ? 'Torrent file uploaded' : 'Error while uploading torrent file');
+            adapter.send(url, null, function (success) {
+                torrentToWeb.notify(success ? 'Magnet link sent' : 'Error while sending magnet link');
+            });
+        });
+    } else {
+        torrentToWeb.notify('Retrieving torrent file');
+
+        const downloadRequest = new Request(url, {
+            method: 'GET',
+            credentials: 'same-origin',
+            referrer: ref,
+        });
+        return fetch(downloadRequest).then((response) => {
+            if (response.status !== 200) {
+                torrentToWeb.notify('Could not download torrent file:' + response.status);
+                return;
+            }
+
+            let filename = torrentToWeb.determineFilename(response);
+            let extension = filename.split('.').pop();
+
+            if (extension !== 'torrent') {
+                torrentToWeb.notify('File is not a torrent');
+                return;
+            }
+
+            torrentToWeb.notify('Uploading torrent file');
+            torrentToWeb.createAdapter(function (adapter) {
+                response.blob().then(function (blob) {
+                    adapter.send(filename, blob, function (success) {
+                        torrentToWeb.notify(success ? 'Torrent file uploaded' : 'Error while uploading torrent file');
+                    });
                 });
             });
         });
-    });
+    }
 };
 
 torrentToWeb.createAdapter = function (callback) {


### PR DESCRIPTION
Subject says it all.

Tested with:
* ruTorrent 3.8
* transmission 2.94
* deluge 1.3.15

### Notes
While going thru the code of the adapters, I noticed some deficiencies:
Error handling is generally almost nonexistent.
The deluge implementation is quite incomplete. It should do the following.
1. Send login request
2. If status != 200 => connect error
3. If result != true => Invalid password
4. Send web.connected query
5. If status != 200 => connect error
6. If result != true => deluge-web not connected to deluge-daemon error
7. Send file or url
8. If status != 200 => send error
Currently, it performs only 1, 2, 7 and 8
For being able to show precise error messages to the user, I propose, that the parameter of the toplevel callback should be changed to a string:
If null: Everything is ok
If not null: Contains a reason or some hints. This could then be shown via notifications.

What do you think? (Would be a separate PR)

Cheers
 -Fritz