### PR TITLE
Add support for qBittorrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An add-on which allows to send torrent files to web clients.
 
 Currently the following clients are supported:
 
-- RuTorrent
+- Deluge
+- qBittorrent
+- ruTorrent
 - Transmission
 

--- a/background/adapter/deluge.js
+++ b/background/adapter/deluge.js
@@ -49,6 +49,7 @@ torrentToWeb.adapter.deluge = function (baseUrl, username, password, autostart) 
                 });
                 return;
             }
+
             let fileReader = new FileReader();
 
             fileReader.addEventListener('load', function () {

--- a/background/adapter/qbittorrent.js
+++ b/background/adapter/qbittorrent.js
@@ -57,28 +57,13 @@ torrentToWeb.adapter.qbittorrent = function (baseUrl, username, password, autost
             }
 
             if (filenameOrUrl.startsWith('magnet:')) {
-                installFilter();
-                login().then(() => {
-                    requestData.append('urls', filenameOrUrl + '\n');
-                    sendAddRequest(requestData).then(() => {
-                        logout();
-                        callback(true);
-                    }, (error) => {
-                        console.log(error);
-                        removeFilter();
-                        callback(false);
-                    });
-                }, (error) => {
-                    console.log(error);
-                    removeFilter();
-                    callback(false);
-                });
-                return;
+                requestData.append('urls', filenameOrUrl + '\n');
+            } else {
+                requestData.append('torrents', data, filenameOrUrl);
             }
 
             installFilter();
             login().then(() => {
-                requestData.append('torrents', data, filenameOrUrl);
                 sendAddRequest(requestData).then(() => {
                     logout();
                     callback(true);
@@ -92,6 +77,7 @@ torrentToWeb.adapter.qbittorrent = function (baseUrl, username, password, autost
                 removeFilter();
                 callback(false);
             });
+            return;
         }
     };
 

--- a/background/adapter/qbittorrent.js
+++ b/background/adapter/qbittorrent.js
@@ -1,0 +1,152 @@
+'use strict';
+
+torrentToWeb.adapter.qbittorrent = function (baseUrl, username, password, autostart) {
+    let baseUrlObject = new URL(baseUrl);
+    baseUrlObject.pathname = '/api/v2';
+
+    baseUrl = baseUrlObject.toString();
+    let refUrl = baseUrl.replace(/(:\d+).*$/, '$1');
+    let filterUrls = refUrl.replace(/:\d+.*$/, '/*');
+    let sessionCookie = null;
+
+    function login () {
+        let requestData = new URLSearchParams();
+        requestData.append('username', username);
+        requestData.append('password', password);
+
+        return new Promise((resolve, reject) => {
+            fetch(baseUrl + '/auth/login', {
+                method: 'POST',
+                credentials: 'omit',
+                body: requestData,
+            }).then((response) => {
+                if (response.ok) {
+                    return response.text();
+                }
+
+                throw new Error(response.status.toString() + ': ' + response.statusText);
+            }).then((txt) => {
+                if (txt === 'Ok.') {
+                    resolve();
+                    return;
+                }
+
+                throw new Error('Login error: ' + txt);
+            }).catch((error) => reject(error));
+        });
+    }
+
+    function logout () {
+        return new Promise((resolve, reject) => {
+            fetch(baseUrl + '/auth/logout', {
+                method: 'POST',
+            }).finally(() => {
+                sessionCookie = null;
+                removeFilter();
+                resolve();
+            }).catch((error) => reject(error));
+        });
+    }
+
+    return {
+        send: function (filenameOrUrl, data, callback) {
+            let requestData = new FormData();
+
+            if (! autostart) {
+                requestData.append('paused', 'true');
+            }
+
+            if (filenameOrUrl.startsWith('magnet:')) {
+                installFilter();
+                login().then(() => {
+                    requestData.append('urls', filenameOrUrl + '\n');
+                    sendAddRequest(requestData).then(() => {
+                        logout();
+                        callback(true);
+                    });
+                });
+                return;
+            }
+
+            installFilter();
+            login().then(() => {
+                requestData.append('torrents', data, filenameOrUrl);
+                sendAddRequest(requestData).then(() => {
+                    logout();
+                    callback(true);
+                });
+            });
+        }
+    };
+
+    function sendAddRequest (requestData) {
+        return new Promise((resolve, reject) => {
+            fetch(baseUrl + '/torrents/add', {
+                method: 'POST',
+                body: requestData,
+            }).then((response) => {
+                if (response.ok) {
+                    resolve();
+                    return;
+                }
+
+                throw new Error('Could not add torrent');
+            }).catch((error) => reject(error));
+        });
+    }
+
+    function removeHeaders (headers, unwanted) {
+        return headers.filter((header) => {
+            return ! unwanted.includes(header.name.toLowerCase());
+        });
+    }
+
+    function receiveFilter (details) {
+        let headers = details.responseHeaders;
+        let cookie = headers.find((header) => {
+            return header.name.toLowerCase() === 'set-cookie';
+        });
+
+        if (cookie) {
+            sessionCookie = cookie.value.replace(/;.*$/, '');
+        }
+
+        return {
+            responseHeaders: removeHeaders(headers, ['set-cookie'])
+        };
+    }
+
+    function sendFilter (details) {
+        let headers = removeHeaders(details.requestHeaders, [
+            'cookie', 'origin', 'referer',
+        ]);
+        headers.push({name: 'Referer', value: refUrl});
+        headers.push({name: 'Origin', value: refUrl});
+
+        if (sessionCookie) {
+            headers.push({name: 'Cookie', value: sessionCookie});
+        }
+
+        return {
+            requestHeaders: headers
+        };
+    }
+
+    function installFilter () {
+        chrome.webRequest.onBeforeSendHeaders.addListener(
+            sendFilter,
+            {urls: [filterUrls]},
+            ['blocking', 'requestHeaders']
+        );
+        chrome.webRequest.onHeadersReceived.addListener(
+            receiveFilter,
+            {urls: [filterUrls]},
+            ['blocking', 'responseHeaders']
+        );
+    }
+
+    function removeFilter () {
+        chrome.webRequest.onHeadersReceived.removeListener(receiveFilter);
+        chrome.webRequest.onBeforeSendHeaders.removeListener(sendFilter);
+    }
+};

--- a/background/adapter/qbittorrent.js
+++ b/background/adapter/qbittorrent.js
@@ -63,7 +63,15 @@ torrentToWeb.adapter.qbittorrent = function (baseUrl, username, password, autost
                     sendAddRequest(requestData).then(() => {
                         logout();
                         callback(true);
+                    }, (error) => {
+                        console.log(error);
+                        removeFilter();
+                        callback(false);
                     });
+                }, (error) => {
+                    console.log(error);
+                    removeFilter();
+                    callback(false);
                 });
                 return;
             }
@@ -74,7 +82,15 @@ torrentToWeb.adapter.qbittorrent = function (baseUrl, username, password, autost
                 sendAddRequest(requestData).then(() => {
                     logout();
                     callback(true);
+                }, (error) => {
+                    console.log(error);
+                    removeFilter();
+                    callback(false);
                 });
+            }, (error) => {
+                console.log(error);
+                removeFilter();
+                callback(false);
             });
         }
     };

--- a/background/adapter/qbittorrent.js
+++ b/background/adapter/qbittorrent.js
@@ -77,7 +77,6 @@ torrentToWeb.adapter.qbittorrent = function (baseUrl, username, password, autost
                 removeFilter();
                 callback(false);
             });
-            return;
         }
     };
 

--- a/background/adapter/transmission.js
+++ b/background/adapter/transmission.js
@@ -23,6 +23,7 @@ torrentToWeb.adapter.transmission = function (baseUrl, username, password, autos
                 sendRequest(requestData, callback, null);
                 return;
             }
+
             let fileReader = new FileReader();
             fileReader.addEventListener('load', function () {
                 let requestData = {

--- a/background/main.js
+++ b/background/main.js
@@ -12,8 +12,10 @@ torrentToWeb.processUrl = function (url, ref) {
                 torrentToWeb.notify(success ? 'Magnet link sent' : 'Error while sending magnet link');
             });
         });
+
         return;
     }
+
     torrentToWeb.notify('Retrieving torrent file');
 
     const downloadRequest = new Request(url, {

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,9 @@
         "<all_urls>",
         "contextMenus",
         "notifications",
-        "storage"
+        "storage",
+        "webRequest",
+        "webRequestBlocking"
     ],
     "options_ui": {
         "page": "options/options.html"
@@ -26,6 +28,7 @@
             "background/main.js",
             "background/adapter/deluge.js",
             "background/adapter/rutorrent.js",
+            "background/adapter/qbittorrent.js",
             "background/adapter/transmission.js"
         ]
     }

--- a/options/options.html
+++ b/options/options.html
@@ -14,6 +14,7 @@
                     <label for="adapter">Client</label>
                     <select id="adapter" class="form-control">
                         <option value="deluge">Deluge</option>
+                        <option value="qbittorrent">qBittorrent</option>
                         <option value="rutorrent">ruTorrent</option>
                         <option value="transmission">Transmission</option>
                     </select>


### PR DESCRIPTION
Hi,

Subject says it all.
just in case you did not yet release :-)

This was rather tricky, because qBittorrent turned out to be quite picky about Referrer and Origin headers. Also, it needs a session cookie. So with this one, now there are 2 new permissions required.
Oh, and implemented it using fetch API and [this](https://github.com/qbittorrent/qBittorrent/wiki/Web-API-Documentation) spec.

Tested with qBittorrent v4.1.5
Fixes: #7 and #19