### PR TITLE
Get torrent name from torrent-file

### DIFF
--- a/background/decode.js
+++ b/background/decode.js
@@ -1,0 +1,180 @@
+'use strict';
+/**
+ * This file was taken from https://github.com/themasch/node-bencode/blob/master/lib/decode.js
+ * and ported to use native UInt8Array/ArrayBuffer in order to get rid of node dependencies.
+ * Original license: MIT
+ */
+
+/**
+ * Decodes bencoded data like torrent files.
+ *
+ * @param  {ArrayBuffer} data
+ * @return {Object|Array|Buffer|String|Number}
+ */
+function decode (data) {
+    if (data == null || data.length === 0) {
+        return null;
+    }
+
+    decode.position = 0;
+    decode.data = new Uint8Array(data);
+    decode.bytes = decode.data.length;
+    return decode.next();
+}
+
+decode.bytes = 0;
+decode.position = 0;
+decode.data = null;
+
+const INTEGER_START = 0x69; // 'i'
+const STRING_DELIM = 0x3A; // ':'
+const DICTIONARY_START = 0x64; // 'd'
+const LIST_START = 0x6C; // 'l'
+const END_OF_TYPE = 0x65; // 'e'
+
+decode.getIntFromBuffer = function (data, start, end) {
+    let sum = 0;
+    let sign = 1;
+
+    for (let i = start; i < end; i++) {
+        let num = data[i];
+
+        if (num < 58 && num >= 48) {
+            sum = sum * 10 + (num - 48);
+            continue;
+        }
+
+        if (i === start && num === 43) { // +
+            continue;
+        }
+
+        if (i === start && num === 45) { // -
+            sign = - 1;
+            continue;
+        }
+
+        if (num === 46) { // .
+            // its a float. break here.
+            break;
+        }
+
+        throw new Error('not a number: data[' + i + '] = ' + num);
+    }
+
+    return sum * sign;
+}
+
+decode.next = function () {
+    switch (decode.data[decode.position]) {
+        case DICTIONARY_START:
+            return decode.dictionary();
+        case LIST_START:
+            return decode.list();
+        case INTEGER_START:
+            return decode.integer();
+        default:
+            return decode.buffer();
+    }
+};
+
+decode.find = function (chr) {
+    let i = decode.position;
+    const c = decode.data.length;
+    const d = decode.data;
+
+    while (i < c) {
+        if (d[i] === chr) {
+            return i;
+        }
+
+        i++;
+    }
+
+    throw new Error(
+        'Invalid data: Missing delimiter "'
+        + String.fromCharCode(chr)
+        + '" [0x' + chr.toString(16) + ']'
+    );
+};
+
+decode.dictionary = function () {
+    decode.position++;
+
+    let dict = {};
+
+    while (decode.data[decode.position] !== END_OF_TYPE) {
+        dict[decode.buffer()] = decode.next();
+    }
+
+    decode.position++;
+
+    return dict;
+};
+
+decode.list = function () {
+    decode.position++;
+
+    let lst = [];
+
+    while (decode.data[decode.position] !== END_OF_TYPE) {
+        lst.push(decode.next());
+    }
+
+    decode.position++;
+
+    return lst;
+};
+
+decode.integer = function () {
+    const end = decode.find(END_OF_TYPE);
+    const number = decode.getIntFromBuffer(decode.data, decode.position + 1, end);
+
+    decode.position += end + 1 - decode.position;
+
+    return number;
+};
+
+decode.toString = function (array) {
+    const len = array.length;
+    let out = '';
+    let i = 0;
+    let c;
+    let char2;
+    let char3;
+
+    while (i < len) {
+        c = array[i++];
+        switch (c >> 4) {
+            case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7:
+
+                // 0xxxxxxx
+                out += String.fromCharCode(c);
+            break;
+            case 12: case 13:
+
+                // 110x xxxx   10xx xxxx
+                char2 = array[i++];
+                out += String.fromCharCode(((c & 0x1F) << 6) | (char2 & 0x3F));
+            break;
+            case 14:
+
+                // 1110 xxxx  10xx xxxx  10xx xxxx
+                char2 = array[i++];
+                char3 = array[i++];
+                out += String.fromCharCode(((c & 0x0F) << 12)
+                                           | ((char2 & 0x3F) << 6)
+                                           | ((char3 & 0x3F) << 0));
+            break;
+        }
+    }
+
+    return out;
+};
+
+decode.buffer = function () {
+    let sep = decode.find(STRING_DELIM);
+    const length = decode.getIntFromBuffer(decode.data, decode.position, sep);
+    const end = ++ sep + length;
+    decode.position = end;
+    return decode.toString(decode.data.slice(sep, end));
+};

--- a/background/decode.js
+++ b/background/decode.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /**
  * This file was taken from https://github.com/themasch/node-bencode/blob/master/lib/decode.js
  * and ported to use native UInt8Array/ArrayBuffer in order to get rid of node dependencies.
@@ -62,7 +63,7 @@ decode.getIntFromBuffer = function (data, start, end) {
     }
 
     return sum * sign;
-}
+};
 
 decode.next = function () {
     switch (decode.data[decode.position]) {

--- a/background/main.js
+++ b/background/main.js
@@ -83,7 +83,7 @@ torrentToWeb.determineFilename = function (blob) {
             let torrent;
             try {
                 torrent = decode(buffer);
-            } catch {
+            } catch (error) {
                 resolve(false);
                 return;
             }

--- a/background/main.js
+++ b/background/main.js
@@ -1,5 +1,16 @@
 'use strict';
 
+// No need for FileReader anymore.
+// See https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer#Polyfill
+Object.defineProperty(Blob.prototype, 'arrayBuffer', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function arrayBuffer () {
+        return new Response(this).arrayBuffer();
+    },
+});
+
 let torrentToWeb = {
     adapter: {},
 };
@@ -25,23 +36,30 @@ torrentToWeb.processUrl = function (url, ref) {
     });
     return fetch(downloadRequest).then((response) => {
         if (response.status !== 200) {
-            torrentToWeb.notify('Could not download torrent file:' + response.status);
+            torrentToWeb.notify('Could not download torrent file:'
+                                + response.status + response.statustext);
             return;
         }
 
-        let filename = torrentToWeb.determineFilename(response);
-        let extension = filename.split('.').pop();
+        let ctype = response.headers.get('content-type');
 
-        if (extension !== 'torrent') {
-            torrentToWeb.notify('File is not a torrent');
+        if (! ctype.match(/(application\/x-bittorrent|application\/octet-stream)/gi)) {
+            torrentToWeb.notify('Content-Type is invalid');
             return;
         }
 
-        torrentToWeb.notify('Uploading torrent file');
-        torrentToWeb.createAdapter(function (adapter) {
-            response.blob().then(function (blob) {
-                adapter.send(filename, blob, function (success) {
-                    torrentToWeb.notify(success ? 'Torrent file uploaded' : 'Error while uploading torrent file');
+        response.blob().then(function (blob) {
+            torrentToWeb.determineFilename(blob).then(function (filename) {
+                if (filename === false) {
+                    torrentToWeb.notify('File is not a torrent');
+                    return;
+                }
+
+                torrentToWeb.notify('Uploading torrent file');
+                torrentToWeb.createAdapter(function (adapter) {
+                    adapter.send(filename, blob, function (success) {
+                        torrentToWeb.notify(success ? 'Torrent file uploaded' : 'Error while uploading torrent file');
+                    });
                 });
             });
         });
@@ -59,33 +77,30 @@ torrentToWeb.createAdapter = function (callback) {
     });
 };
 
-torrentToWeb.determineFilename = function (response) {
-    let filename = null;
-    let result;
-    let filenameHeader = response.headers.get('filename');
-    let nameHeader = response.headers.get('name');
-    let contentHeader = response.headers.get('content-disposition');
+torrentToWeb.determineFilename = function (blob) {
+    return new Promise((resolve) => {
+        blob.arrayBuffer().then((buffer) => {
+            let torrent;
+            try {
+                torrent = decode(buffer);
+            } catch {
+                resolve(false);
+                return;
+            }
 
-    if (filenameHeader !== null && filenameHeader !== '') {
-        console.log('Found filename in "filename" header');
-        filename = filenameHeader;
-    } else if (nameHeader !== null && nameHeader !== '') {
-        console.log('Found filename in "name" header');
-        filename = nameHeader;
-    } else if (contentHeader !== null && (result = contentHeader.match(/filename=(?:"([^"]+)"|([^;]+);?)/))) {
-        console.log('Found filename in "content-disposition" header');
-        filename = (typeof result[1] !== 'undefined' ? result[1] : result[2]);
-    } else {
-        console.log('Falling back to filename from URL');
-        filename = new URL(response.url).pathname.split('/').pop();
-    }
+            if (torrent.info && (torrent.info.name || torrent.info.name.utf8)) {
+                if (torrent.info.name.utf8) {
+                    resolve(torrent.info.name.utf8);
+                    return;
+                }
 
-    filename = filename.replace(/[^0-9a-zA-Z.]+/g, '.');
-    filename = filename.replace(/\.{2,}/g, '.');
-    filename = filename.replace(/(^\.+|\.+$)/g, '');
+                resolve(torrent.info.name);
+                return;
+            }
 
-    console.log('Using filename "' + filename + '"');
-    return filename;
+            resolve(false);
+        });
+    });
 };
 
 torrentToWeb.notify = function (message) {

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
     },
     "background": {
         "scripts": [
+            "background/decode.js",
             "background/main.js",
             "background/adapter/deluge.js",
             "background/adapter/rutorrent.js",


### PR DESCRIPTION
This PR changes the way of determining the torrent name:

Instead of relying on response headers, the actual torrent data is examined. According to [the spec](https://www.bittorrent.org/beps/bep_0003.html), it contains a mandatory field _info.name_ which is exactly what we need. Some torrent generators also produce a field _info.name.utf8_. If the latter exists, it takes precedence.

The necessary ability to decode bencoded data (the torrent data) was taken from [node-bencode](https://github.com/themasch/node-bencode/blob/master/lib/decode.js) and ported to use native UInt8Array/ArrayBuffer in order to get rid of node dependencies. The original is licensed under MIT license.

Fixes: #3 and #11