### PR TITLE
Handle left-click on magnet links

### DIFF
--- a/background/main.js
+++ b/background/main.js
@@ -117,3 +117,7 @@ browser.contextMenus.onClicked.addListener(function (info) {
     let ref = (info.frameUrl) ? info.frameUrl : info.pageUrl;
     torrentToWeb.processUrl(info.linkUrl, ref);
 });
+
+browser.runtime.onMessage.addListener(function (url) {
+    torrentToWeb.processUrl(url, null);
+});

--- a/content/script.js
+++ b/content/script.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function notifyBackground (e) {
+    let target = e.target;
+    while ((target.tagName != 'A' || ! target.href) && target.parentNode) {
+        target = target.parentNode;
+    }
+
+    if (target.tagName != 'A') {
+        return;
+    }
+
+    if (target.href.startsWith('magnet:')) {
+        e.stopPropagation();
+        e.preventDefault();
+        browser.runtime.sendMessage(target.href);
+    }
+}
+
+window.addEventListener('click', notifyBackground);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ const checkCs = () => {
     return gulp.src([
         'background/**/*.js',
         'options/**/*.js',
+        'content/**/*.js',
     ], {base: './'})
         .pipe(jscs())
         .pipe(jscs.reporter())
@@ -19,6 +20,7 @@ const build = () => {
         'LICENSE',
         'manifest.json',
         'options/**/*',
+        'content/**/*',
     ], {base: './'})
         .pipe(zip('torrent-to-web.xpi'))
         .pipe(gulp.dest('./'));

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,12 @@
             "background/adapter/qbittorrent.js",
             "background/adapter/transmission.js"
         ]
-    }
+    },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content/script.js"]
+        }
+    ]
 }
 


### PR DESCRIPTION
This PR adds a left-click handler for magnet links that gets injected into pages. Since those links can be easily identified by their magnet: prefix, there is actually no need to use the context menu for sending.