### PR TITLE
Notify user if config is missing

### DIFF
--- a/background/main.js
+++ b/background/main.js
@@ -50,6 +50,10 @@ torrentToWeb.processUrl = function (url, ref) {
 
 torrentToWeb.createAdapter = function (callback) {
     browser.storage.local.get(function (options) {
+        if (! options.adapter) {
+            torrentToWeb.notify('Error: Missing configuration.');
+        }
+
         callback(torrentToWeb.adapter[options.adapter](
             options.url,
             options.username,


### PR DESCRIPTION
Just stumbled over an error when I forgot to save extension preferences in a fresh FF instance.
This PR adds a notification about this error.