### PR TITLE
Followup for #26

### DIFF
--- a/background/main.js
+++ b/background/main.js
@@ -49,13 +49,15 @@ torrentToWeb.processUrl = function (url, ref) {
 };
 
 torrentToWeb.createAdapter = function (callback) {
-    browser.storage.local.get(function (options) {
+    browser.storage.local.get().then((options) => {
         callback(torrentToWeb.adapter[options.adapter](
             options.url,
             options.username,
             options.password,
             options.autostart
         ));
+    }, (error) => {
+        console.log(error);
     });
 };
 
@@ -94,7 +96,7 @@ torrentToWeb.notify = function (message) {
 
         {
             type: 'basic',
-            iconUrl: browser.extension.getURL('icons/icon-48.png'),
+            iconUrl: browser.runtime.getURL('icons/icon-48.png'),
             title: 'Torrent to Web',
             message: message,
         }


### PR DESCRIPTION
0adf32f7e49f076e123346d39f4e6ed1f82c1b13 introduced a bug and a deprecation:

1. browser.storage.local.get() returns a Promise. Handling this correctly now.
2. browser.extension.getURL() is deprecated. See:
   https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL
