### PR TITLE
feat: allow choosing a label/category when sending to ruTorrent or qB…

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -36,14 +36,17 @@ const createContextMenu = async (): Promise<void> => {
             contexts: ["link"],
         });
 
-        profile.labels.forEach((label, index) => {
+        // The label travels in the id itself rather than an index into the profile, so the click
+        // handler never has to re-read storage and cannot resolve against a list that changed
+        // since the menu was built.
+        for (const label of profile.labels) {
             browser.contextMenus.create({
-                id: `${parentId}-label-${index}`,
+                id: `${parentId}-label-${encodeURIComponent(label)}`,
                 parentId,
                 title: label,
                 contexts: ["link"],
             });
-        });
+        }
     }
 };
 
@@ -55,7 +58,7 @@ const queueContextMenuUpdate = () => {
     contextMenuUpdate = contextMenuUpdate.then(createContextMenu).catch(handleUncaught);
 };
 
-const contextMenuIdRegexp = /^send-to-torrent-client-(\d+)(?:-nolabel|-label-(\d+))?$/;
+const contextMenuIdRegexp = /^send-to-torrent-client-(\d+)(?:-nolabel|-label-(.+))?$/;
 
 const legacyProfileSchema = z.object({
     nid: z.int().positive(),
@@ -96,30 +99,17 @@ export default defineBackground({
                 return;
             }
 
-            const [, profileIdText, labelIndexText] =
-                contextMenuIdRegexp.exec(info.menuItemId) ?? [];
+            const [, profileIdText, labelText] = contextMenuIdRegexp.exec(info.menuItemId) ?? [];
 
             if (profileIdText === undefined) {
                 return;
             }
 
-            const linkUrl = info.linkUrl;
             const profileId = Number.parseInt(profileIdText, 10);
             const referrer = info.frameUrl ?? info.pageUrl;
+            const label = labelText === undefined ? undefined : decodeURIComponent(labelText);
 
-            (async () => {
-                let label: string | undefined;
-
-                if (labelIndexText !== undefined) {
-                    const labelIndex = Number.parseInt(labelIndexText, 10);
-                    const profile = (await getProfiles()).find(
-                        (profile) => profile.id === profileId,
-                    );
-                    label = profile?.labels[labelIndex];
-                }
-
-                await processUrl(linkUrl, referrer, profileId, label);
-            })().catch(handleUncaught);
+            processUrl(info.linkUrl, referrer, profileId, { label }).catch(handleUncaught);
         });
 
         browser.runtime.onInstalled.addListener((details) => {
@@ -156,7 +146,7 @@ export default defineBackground({
 
         browser.runtime.onMessage.addListener((message: RuntimeMessage) => {
             if (message.magnetUrl) {
-                processUrl(message.magnetUrl, undefined, undefined).catch(handleUncaught);
+                processUrl(message.magnetUrl, undefined, undefined, {}).catch(handleUncaught);
             }
 
             if (message.test) {
@@ -168,7 +158,7 @@ export default defineBackground({
                     const testTorrent = await createTestTorrent();
 
                     try {
-                        await client.sendTorrent("test.torrent", testTorrent);
+                        await client.sendTorrent("test.torrent", testTorrent, {});
                     } catch (error) {
                         await notification.error("Error occurred when testing profile");
                         console.debug(

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -10,10 +10,39 @@ const createContextMenu = async (): Promise<void> => {
     const profiles = await getProfiles();
 
     for (const profile of profiles) {
+        const parentId = `send-to-torrent-client-${profile.id}`;
+
         browser.contextMenus.create({
-            id: `send-to-torrent-client-${profile.id}`,
+            id: parentId,
             title: `Send torrent to ${profile.name}`,
             contexts: ["link"],
+        });
+
+        if (profile.labels.length === 0) {
+            continue;
+        }
+
+        browser.contextMenus.create({
+            id: `${parentId}-nolabel`,
+            parentId,
+            title: "No label",
+            contexts: ["link"],
+        });
+
+        browser.contextMenus.create({
+            id: `${parentId}-separator`,
+            parentId,
+            type: "separator",
+            contexts: ["link"],
+        });
+
+        profile.labels.forEach((label, index) => {
+            browser.contextMenus.create({
+                id: `${parentId}-label-${index}`,
+                parentId,
+                title: label,
+                contexts: ["link"],
+            });
         });
     }
 };
@@ -26,7 +55,7 @@ const queueContextMenuUpdate = () => {
     contextMenuUpdate = contextMenuUpdate.then(createContextMenu).catch(handleUncaught);
 };
 
-const contextMenuIdRegexp = /^send-to-torrent-client-(\d+)$/;
+const contextMenuIdRegexp = /^send-to-torrent-client-(\d+)(?:-nolabel|-label-(\d+))?$/;
 
 const legacyProfileSchema = z.object({
     nid: z.int().positive(),
@@ -67,16 +96,30 @@ export default defineBackground({
                 return;
             }
 
-            const [, profileIdText] = contextMenuIdRegexp.exec(info.menuItemId) ?? [];
+            const [, profileIdText, labelIndexText] =
+                contextMenuIdRegexp.exec(info.menuItemId) ?? [];
 
             if (profileIdText === undefined) {
                 return;
             }
 
+            const linkUrl = info.linkUrl;
             const profileId = Number.parseInt(profileIdText, 10);
             const referrer = info.frameUrl ?? info.pageUrl;
 
-            processUrl(info.linkUrl, referrer, profileId).catch(handleUncaught);
+            (async () => {
+                let label: string | undefined;
+
+                if (labelIndexText !== undefined) {
+                    const labelIndex = Number.parseInt(labelIndexText, 10);
+                    const profile = (await getProfiles()).find(
+                        (profile) => profile.id === profileId,
+                    );
+                    label = profile?.labels[labelIndex];
+                }
+
+                await processUrl(linkUrl, referrer, profileId, label);
+            })().catch(handleUncaught);
         });
 
         browser.runtime.onInstalled.addListener((details) => {
@@ -102,6 +145,7 @@ export default defineBackground({
                             password: parseResult.data.password,
                             autostart: parseResult.data.autostart,
                             handleLeftClick: parseResult.data.magnet,
+                            labels: [],
                         });
                     }
                 }

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -47,12 +47,12 @@
                     </div>
                 </div>
 
-                <div class="mb-3" id="labelsGroup">
+                <div class="mb-3">
                     <label for="labels" class="form-label">Labels</label>
-                    <input type="text" class="form-control" id="labels" placeholder="Films, Séries, Musique">
+                    <input type="text" class="form-control" id="labels" placeholder="Movies, Series, Music">
                     <div class="form-text">
                         Comma-separated. When set, the context menu offers a submenu to pick a label
-                        (ruTorrent label / qBittorrent category) for each torrent.
+                        for each torrent.
                     </div>
                 </div>
 

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -47,6 +47,15 @@
                     </div>
                 </div>
 
+                <div class="mb-3" id="labelsGroup">
+                    <label for="labels" class="form-label">Labels</label>
+                    <input type="text" class="form-control" id="labels" placeholder="Films, Séries, Musique">
+                    <div class="form-text">
+                        Comma-separated. When set, the context menu offers a submenu to pick a label
+                        (ruTorrent label / qBittorrent category) for each torrent.
+                    </div>
+                </div>
+
                 <div class="form-check">
                     <input class="form-check-input" type="checkbox" id="handleLeftClick">
                     <label class="form-check-label" for="handleLeftClick">

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -1,5 +1,6 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import type { ClientName } from "../../utils/client";
+import { labelCapableClients } from "../../utils/client";
 
 const form = document.querySelector("#form") as HTMLFormElement;
 const profileSelect = document.querySelector("#profiles") as HTMLSelectElement;
@@ -10,6 +11,8 @@ const usernameInput = document.querySelector("#username") as HTMLInputElement;
 const passwordInput = document.querySelector("#password") as HTMLInputElement;
 const handleLeftClickCheckbox = document.querySelector("#handleLeftClick") as HTMLInputElement;
 const autostartCheckbox = document.querySelector("#autostart") as HTMLInputElement;
+const labelsInput = document.querySelector("#labels") as HTMLInputElement;
+const labelsGroup = document.querySelector("#labelsGroup") as HTMLDivElement;
 const testButton = document.querySelector("#test") as HTMLButtonElement;
 const removeButton = document.querySelector("#remove") as HTMLButtonElement;
 const passwordToggleButton = document.querySelector("#passwordToggle") as HTMLButtonElement;
@@ -36,8 +39,29 @@ const updateUsernameInput = () => {
     usernameInput.disabled = clientSelect.value === "deluge";
 };
 
+const updateLabelsInput = () => {
+    labelsGroup.hidden = !labelCapableClients.includes(clientSelect.value as ClientName);
+};
+
+const parseLabels = (value: string): string[] => {
+    const seen = new Set<string>();
+
+    return value
+        .split(",")
+        .map((label) => label.trim())
+        .filter((label) => {
+            if (label === "" || seen.has(label)) {
+                return false;
+            }
+
+            seen.add(label);
+            return true;
+        });
+};
+
 clientSelect.addEventListener("change", () => {
     updateUsernameInput();
+    updateLabelsInput();
 });
 
 const selectProfile = (profileId: number | undefined) => {
@@ -55,6 +79,8 @@ const selectProfile = (profileId: number | undefined) => {
         passwordInput.value = currentProfile.password;
         handleLeftClickCheckbox.checked = currentProfile.handleLeftClick;
         autostartCheckbox.checked = currentProfile.autostart;
+        // Profiles saved before labels existed have no such key in storage.
+        labelsInput.value = ((currentProfile.labels as string[] | undefined) ?? []).join(", ");
         testButton.disabled = false;
         removeButton.disabled = false;
     } else {
@@ -65,13 +91,15 @@ const selectProfile = (profileId: number | undefined) => {
         passwordInput.value = "";
         handleLeftClickCheckbox.checked = false;
         autostartCheckbox.checked = false;
+        labelsInput.value = "";
         testButton.disabled = true;
         removeButton.disabled = true;
     }
 
-    // Assigning clientSelect.value does not raise a change event, so the username state has to be
-    // brought along by hand on both paths.
+    // Assigning clientSelect.value does not raise a change event, so the username and labels
+    // state has to be brought along by hand on both paths.
     updateUsernameInput();
+    updateLabelsInput();
 };
 
 loadProfiles()
@@ -138,6 +166,9 @@ form.addEventListener("submit", (event) => {
         password: passwordInput.value,
         handleLeftClick: handleLeftClickCheckbox.checked,
         autostart: autostartCheckbox.checked,
+        labels: labelCapableClients.includes(clientSelect.value as ClientName)
+            ? parseLabels(labelsInput.value)
+            : [],
     };
 
     if (currentProfile) {

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -12,7 +12,6 @@ const passwordInput = document.querySelector("#password") as HTMLInputElement;
 const handleLeftClickCheckbox = document.querySelector("#handleLeftClick") as HTMLInputElement;
 const autostartCheckbox = document.querySelector("#autostart") as HTMLInputElement;
 const labelsInput = document.querySelector("#labels") as HTMLInputElement;
-const labelsGroup = document.querySelector("#labelsGroup") as HTMLDivElement;
 const testButton = document.querySelector("#test") as HTMLButtonElement;
 const removeButton = document.querySelector("#remove") as HTMLButtonElement;
 const passwordToggleButton = document.querySelector("#passwordToggle") as HTMLButtonElement;
@@ -30,8 +29,7 @@ const renderProfileOptions = () => {
 };
 
 const loadProfiles = async () => {
-    const storage = await browser.storage.local.get("profiles");
-    profiles = (storage.profiles ?? []) as Profile[];
+    profiles = await getProfiles();
     renderProfileOptions();
 };
 
@@ -40,7 +38,7 @@ const updateUsernameInput = () => {
 };
 
 const updateLabelsInput = () => {
-    labelsGroup.hidden = !labelCapableClients.includes(clientSelect.value as ClientName);
+    labelsInput.disabled = !labelCapableClients.includes(clientSelect.value as ClientName);
 };
 
 const parseLabels = (value: string): string[] => {
@@ -79,8 +77,7 @@ const selectProfile = (profileId: number | undefined) => {
         passwordInput.value = currentProfile.password;
         handleLeftClickCheckbox.checked = currentProfile.handleLeftClick;
         autostartCheckbox.checked = currentProfile.autostart;
-        // Profiles saved before labels existed have no such key in storage.
-        labelsInput.value = ((currentProfile.labels as string[] | undefined) ?? []).join(", ");
+        labelsInput.value = currentProfile.labels.join(", ");
         testButton.disabled = false;
         removeButton.disabled = false;
     } else {

--- a/utils/bencode.ts
+++ b/utils/bencode.ts
@@ -139,14 +139,33 @@ class Decoder {
                 // fromCodePoint rather than fromCharCode. Lead bytes of 0x80 to 0xbf still fall
                 // through and are skipped, because torrent names are not reliably utf-8 and
                 // rejecting them outright would fail uploads that currently succeed.
-                case 15:
-                    result += String.fromCodePoint(
+                //
+                // Binary fields such as the piece hashes flow through here as well, so invalid
+                // lead bytes (above 0xf4), sequences cut off by the end of the buffer, and code
+                // points beyond the Unicode range are skipped in the same way rather than thrown
+                // on, which fromCodePoint would otherwise do.
+                case 15: {
+                    if (character > 0xf4) {
+                        break;
+                    }
+
+                    if (position + 3 > data.length) {
+                        position = data.length;
+                        break;
+                    }
+
+                    const codePoint =
                         ((character & 0x07) << 18) |
-                            ((nextByte() & 0x3f) << 12) |
-                            ((nextByte() & 0x3f) << 6) |
-                            (nextByte() & 0x3f),
-                    );
+                        ((nextByte() & 0x3f) << 12) |
+                        ((nextByte() & 0x3f) << 6) |
+                        (nextByte() & 0x3f);
+
+                    if (codePoint <= 0x10ffff) {
+                        result += String.fromCodePoint(codePoint);
+                    }
+
                     break;
+                }
             }
         }
 

--- a/utils/client/deluge.ts
+++ b/utils/client/deluge.ts
@@ -3,6 +3,8 @@ import type { Client, ClientConfig } from "./index";
 import { fetchExtractCookies, fetchWithCookies } from "./utils";
 
 export class Deluge implements Client {
+    public static readonly supportsLabels = false;
+
     private readonly config: ClientConfig;
     private readonly url: URL;
 

--- a/utils/client/index.ts
+++ b/utils/client/index.ts
@@ -15,8 +15,8 @@ export type SendOptions = {
 };
 
 export type Client = {
-    sendTorrent: (filename: string, torrent: Blob, options?: SendOptions) => Promise<void>;
-    sendMagnetUrl: (url: string, options?: SendOptions) => Promise<void>;
+    sendTorrent: (filename: string, torrent: Blob, options: SendOptions) => Promise<void>;
+    sendMagnetUrl: (url: string, options: SendOptions) => Promise<void>;
 };
 
 export const clients = {
@@ -29,7 +29,6 @@ export const clients = {
 export type ClientName = keyof typeof clients;
 export const clientNames = Object.keys(clients) as unknown as Readonly<[ClientName]>;
 
-/**
- * Clients for which a label/category can be attached to a torrent at send time.
- */
-export const labelCapableClients: readonly ClientName[] = ["rutorrent", "qbittorrent"];
+export const labelCapableClients = Object.entries(clients)
+    .filter(([, client]) => client.supportsLabels)
+    .map(([name]) => name as ClientName);

--- a/utils/client/index.ts
+++ b/utils/client/index.ts
@@ -10,9 +10,13 @@ export type ClientConfig = {
     autostart: boolean;
 };
 
+export type SendOptions = {
+    label?: string;
+};
+
 export type Client = {
-    sendTorrent: (filename: string, torrent: Blob) => Promise<void>;
-    sendMagnetUrl: (url: string) => Promise<void>;
+    sendTorrent: (filename: string, torrent: Blob, options?: SendOptions) => Promise<void>;
+    sendMagnetUrl: (url: string, options?: SendOptions) => Promise<void>;
 };
 
 export const clients = {
@@ -24,3 +28,8 @@ export const clients = {
 
 export type ClientName = keyof typeof clients;
 export const clientNames = Object.keys(clients) as unknown as Readonly<[ClientName]>;
+
+/**
+ * Clients for which a label/category can be attached to a torrent at send time.
+ */
+export const labelCapableClients: readonly ClientName[] = ["rutorrent", "qbittorrent"];

--- a/utils/client/qbittorrent.ts
+++ b/utils/client/qbittorrent.ts
@@ -1,4 +1,4 @@
-import type { Client, ClientConfig } from "./index";
+import type { Client, ClientConfig, SendOptions } from "./index";
 import { fetchExtractCookies, fetchWithCookies, spoofOrigin } from "./utils";
 
 const loginPath = "/api/v2/auth/login";
@@ -11,26 +11,34 @@ export class QBittorrent implements Client {
         this.config = config;
     }
 
-    public async sendTorrent(filename: string, torrent: Blob): Promise<void> {
+    public async sendTorrent(
+        filename: string,
+        torrent: Blob,
+        options?: SendOptions,
+    ): Promise<void> {
         const formData = new FormData();
         formData.set("torrents", torrent, filename);
-
-        if (!this.config.autostart) {
-            formData.set("paused", "true");
-        }
+        this.applyCommonFields(formData, options);
 
         return this.sendRequest(formData);
     }
 
-    public async sendMagnetUrl(url: string): Promise<void> {
+    public async sendMagnetUrl(url: string, options?: SendOptions): Promise<void> {
         const formData = new FormData();
         formData.set("urls", `${url}\n`);
+        this.applyCommonFields(formData, options);
 
+        return this.sendRequest(formData);
+    }
+
+    private applyCommonFields(formData: FormData, options?: SendOptions): void {
         if (!this.config.autostart) {
             formData.set("paused", "true");
         }
 
-        return this.sendRequest(formData);
+        if (options?.label) {
+            formData.set("category", options.label);
+        }
     }
 
     // The spoofOrigin patterns have to be built the same way as the requests they are meant to

--- a/utils/client/qbittorrent.ts
+++ b/utils/client/qbittorrent.ts
@@ -5,17 +5,15 @@ const loginPath = "/api/v2/auth/login";
 const addTorrentPath = "/api/v2/torrents/add";
 
 export class QBittorrent implements Client {
+    public static readonly supportsLabels = true;
+
     private readonly config: ClientConfig;
 
     public constructor(config: ClientConfig) {
         this.config = config;
     }
 
-    public async sendTorrent(
-        filename: string,
-        torrent: Blob,
-        options?: SendOptions,
-    ): Promise<void> {
+    public async sendTorrent(filename: string, torrent: Blob, options: SendOptions): Promise<void> {
         const formData = new FormData();
         formData.set("torrents", torrent, filename);
         this.applyCommonFields(formData, options);
@@ -23,7 +21,7 @@ export class QBittorrent implements Client {
         return this.sendRequest(formData);
     }
 
-    public async sendMagnetUrl(url: string, options?: SendOptions): Promise<void> {
+    public async sendMagnetUrl(url: string, options: SendOptions): Promise<void> {
         const formData = new FormData();
         formData.set("urls", `${url}\n`);
         this.applyCommonFields(formData, options);
@@ -31,12 +29,12 @@ export class QBittorrent implements Client {
         return this.sendRequest(formData);
     }
 
-    private applyCommonFields(formData: FormData, options?: SendOptions): void {
+    private applyCommonFields(formData: FormData, options: SendOptions): void {
         if (!this.config.autostart) {
             formData.set("paused", "true");
         }
 
-        if (options?.label) {
+        if (options.label !== undefined) {
             formData.set("category", options.label);
         }
     }

--- a/utils/client/ruTorrent.ts
+++ b/utils/client/ruTorrent.ts
@@ -1,17 +1,15 @@
 import type { Client, ClientConfig, SendOptions } from "./index";
 
 export class RuTorrent implements Client {
+    public static readonly supportsLabels = true;
+
     private readonly config: ClientConfig;
 
     public constructor(config: ClientConfig) {
         this.config = config;
     }
 
-    public async sendTorrent(
-        filename: string,
-        torrent: Blob,
-        options?: SendOptions,
-    ): Promise<void> {
+    public async sendTorrent(filename: string, torrent: Blob, options: SendOptions): Promise<void> {
         const formData = new FormData();
         formData.set("torrent_file", torrent, filename);
         this.applyCommonFields(formData, options);
@@ -19,7 +17,7 @@ export class RuTorrent implements Client {
         return this.sendRequest(formData);
     }
 
-    public async sendMagnetUrl(url: string, options?: SendOptions): Promise<void> {
+    public async sendMagnetUrl(url: string, options: SendOptions): Promise<void> {
         const formData = new FormData();
         formData.set("url", url);
         this.applyCommonFields(formData, options);
@@ -27,12 +25,12 @@ export class RuTorrent implements Client {
         return this.sendRequest(formData);
     }
 
-    private applyCommonFields(formData: FormData, options?: SendOptions): void {
+    private applyCommonFields(formData: FormData, options: SendOptions): void {
         if (!this.config.autostart) {
             formData.set("torrents_start_stopped", "1");
         }
 
-        if (options?.label) {
+        if (options.label !== undefined) {
             formData.set("label", options.label);
         }
     }

--- a/utils/client/ruTorrent.ts
+++ b/utils/client/ruTorrent.ts
@@ -1,4 +1,4 @@
-import type { Client, ClientConfig } from "./index";
+import type { Client, ClientConfig, SendOptions } from "./index";
 
 export class RuTorrent implements Client {
     private readonly config: ClientConfig;
@@ -7,26 +7,34 @@ export class RuTorrent implements Client {
         this.config = config;
     }
 
-    public async sendTorrent(filename: string, torrent: Blob): Promise<void> {
+    public async sendTorrent(
+        filename: string,
+        torrent: Blob,
+        options?: SendOptions,
+    ): Promise<void> {
         const formData = new FormData();
         formData.set("torrent_file", torrent, filename);
-
-        if (!this.config.autostart) {
-            formData.set("torrents_start_stopped", "1");
-        }
+        this.applyCommonFields(formData, options);
 
         return this.sendRequest(formData);
     }
 
-    public async sendMagnetUrl(url: string): Promise<void> {
+    public async sendMagnetUrl(url: string, options?: SendOptions): Promise<void> {
         const formData = new FormData();
         formData.set("url", url);
+        this.applyCommonFields(formData, options);
 
+        return this.sendRequest(formData);
+    }
+
+    private applyCommonFields(formData: FormData, options?: SendOptions): void {
         if (!this.config.autostart) {
             formData.set("torrents_start_stopped", "1");
         }
 
-        return this.sendRequest(formData);
+        if (options?.label) {
+            formData.set("label", options.label);
+        }
     }
 
     private async sendRequest(formData: FormData): Promise<void> {

--- a/utils/client/transmission.ts
+++ b/utils/client/transmission.ts
@@ -2,6 +2,8 @@ import { encode } from "base64-arraybuffer";
 import type { Client, ClientConfig } from "./index";
 
 export class Transmission implements Client {
+    public static readonly supportsLabels = false;
+
     private readonly config: ClientConfig;
 
     public constructor(config: ClientConfig) {

--- a/utils/process.ts
+++ b/utils/process.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { decode } from "./bencode";
-import type { Client } from "./client";
+import type { Client, SendOptions } from "./client";
 import { clients } from "./client";
 import { getProfiles } from "./profiles";
 import { ProgressNotification } from "./progressNotification";
@@ -40,7 +40,11 @@ const createClient = async (profileId: number): Promise<Client> => {
     return new clientConstructor(profile);
 };
 
-const processMagnetUrl = async (url: string, profileId: number | undefined): Promise<void> => {
+const processMagnetUrl = async (
+    url: string,
+    profileId: number | undefined,
+    options: SendOptions,
+): Promise<void> => {
     const notification = await ProgressNotification.create("Sending magnet URL to client(s)");
     let clients: Client[];
 
@@ -61,7 +65,7 @@ const processMagnetUrl = async (url: string, profileId: number | undefined): Pro
 
     for (const client of clients) {
         try {
-            await client.sendMagnetUrl(url);
+            await client.sendMagnetUrl(url, options);
         } catch (error) {
             await notification.error("Failed to send magnet URL to client");
             console.debug(`Send error: ${error instanceof Error ? error.toString() : "Unknown"}`);
@@ -75,6 +79,7 @@ const processTorrent = async (
     url: string,
     referrer: string | undefined,
     profileId: number,
+    options: SendOptions,
 ): Promise<void> => {
     const notification = await ProgressNotification.create("Retrieving torrent file");
 
@@ -114,7 +119,7 @@ const processTorrent = async (
     const client = await createClient(profileId);
 
     try {
-        await client.sendTorrent(filename, blob);
+        await client.sendTorrent(filename, blob, options);
     } catch (error) {
         await notification.error("Failed to send torrent to client");
         console.debug(`Send error: ${error instanceof Error ? error.toString() : "Unknown"}`);
@@ -128,14 +133,17 @@ export const processUrl = async (
     url: string,
     referrer: string | undefined,
     profileId: number | undefined,
+    label?: string,
 ): Promise<void> => {
+    const options: SendOptions = { label };
+
     if (url.startsWith("magnet:")) {
-        return processMagnetUrl(url, profileId);
+        return processMagnetUrl(url, profileId, options);
     }
 
     if (!profileId) {
         throw new Error("Non magnet links require a profile ID");
     }
 
-    return processTorrent(url, referrer, profileId);
+    return processTorrent(url, referrer, profileId, options);
 };

--- a/utils/process.ts
+++ b/utils/process.ts
@@ -133,10 +133,8 @@ export const processUrl = async (
     url: string,
     referrer: string | undefined,
     profileId: number | undefined,
-    label?: string,
+    options: SendOptions,
 ): Promise<void> => {
-    const options: SendOptions = { label };
-
     if (url.startsWith("magnet:")) {
         return processMagnetUrl(url, profileId, options);
     }

--- a/utils/profiles.ts
+++ b/utils/profiles.ts
@@ -10,6 +10,7 @@ const profileSchema = z.object({
     password: z.string(),
     autostart: z.boolean(),
     handleLeftClick: z.boolean(),
+    labels: z.string().array().default([]),
 });
 
 const profilesSchema = profileSchema.array();


### PR DESCRIPTION
…ittorrent

Profiles get an optional comma-separated list of labels. When set, the context menu entry becomes a submenu (No label / <labels>) so the label is picked per torrent. ruTorrent receives it as `label` on addtorrent.php, qBittorrent as `category`. Existing profiles are migrated transparently (default empty list).